### PR TITLE
Fixed broken link for GL-AR750S Travel AC Router

### DIFF
--- a/en/3/index.html
+++ b/en/3/index.html
@@ -2848,7 +2848,7 @@
 <p>Thanks, GL.iNet Team</p>
 <h2 id="wikidevi">Wikidevi</h2>
 <p>GL-B1300 Gigabit AC Router: <a href="https://wikidevi.com/wiki/GL.iNet_GL-B1300">https://wikidevi.com/wiki/GL.iNet_GL-B1300</a></p>
-<p>GL-AR750S Travel AC Router:<a herf="https://wikidevi.com/wiki/GL.iNet_GL-AR750S">https://wikidevi.com/wiki/GL.iNet_GL-AR750S</a></p>
+<p>GL-AR750S Travel AC Router: <a herf="https://wikidevi.com/wiki/GL.iNet_GL-AR750S">https://wikidevi.com/wiki/GL.iNet_GL-AR750S</a></p>
 <p>GL-AR750 Travel AC Router: <a href="https://wikidevi.com/wiki/GL.iNet_GL-AR750">https://wikidevi.com/wiki/GL.iNet_GL-AR750</a></p>
 <p>GL-USB150 Microuter: <a href="https://wikidevi.com/wiki/GL.iNet_GL-USB150">https://wikidevi.com/wiki/GL.iNet_GL-USB150</a></p>
 <p>GL-AR300M Mini Smart Router: <a href="https://wikidevi.com/wiki/GL.iNet_GL-AR300M">https://wikidevi.com/wiki/GL.iNet_GL-AR300M</a></p>


### PR DESCRIPTION
Fixed the broken link for Wikidevi GL-AR750S Travel AC Router:https://wikidevi.com/wiki/GL.iNet_GL-AR750S
It just needed a space after the colon.